### PR TITLE
Add: header追加, Fix: ログイン失敗時flash messageの表示ができる

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,9 @@
   margin-top: 40px;
   text-align: center;
 }
+
+
+
+.nav-item {
+  float: right;
+}

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -7,13 +7,13 @@ class UserSessionsController < ApplicationController
     if @user
       redirect_back_or_to user_path(@user), success: 'ログインに成功しました!'
     else
-      flash.now[:danger] = 'ログインに失敗しました'
-      render :new
+      flash.now[:danger]="ログインできませんでした"
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to login_path, success: 'ログアウトに成功しました!'
+    redirect_to root_path, success: 'ログアウトに成功しました!'
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to login_path, success: 'ユーザー作成できました!'
+      redirect_to login_path, success: 'ユーザー作成できました!ログインしてください'
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,3 +4,6 @@ import "controllers"
 //= require jquery3
 //= require popper
 //= require bootstrap-sprockets
+
+import jquery from "jquery"
+window.$ = jquery

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,9 +8,15 @@
     
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
   </head>
 
   <body>
+    <% if logged_in? %>
+      <%= render 'shared/login_header' %>
+    <% else %>
+      <%= render 'shared/header' %>
+    <% end %>
     <%= render 'shared/flash_message' %>
     <%= yield %>
   </body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,13 @@
+<nav class = "navbar navbar-expand-lg navbar-light" style="background-color: #8CC152;">
+  <div class = "container-fluid">
+    <a class = "navbar-brand">私の多肉こよみ</a>
+    <ul class="navbar-nav mb-2 mb-lg-0">
+      <li class = "nav-item">
+        <%= link_to 'ログイン', login_path , class: "nav-link"%>
+      </li>
+      <li class = "nav-item">  
+        <%= link_to '新規登録', new_user_path, class: "btn btn-success btn-block" %>
+      </li>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/_login_header.html.erb
+++ b/app/views/shared/_login_header.html.erb
@@ -1,0 +1,23 @@
+<nav class = "navbar navbar-expand-lg navbar-light" style="background-color: #8CC152;">
+  <div class = "container-fluid">
+    <a class = "navbar-brand">私の多肉こよみ</a>
+    <ul class="navbar-nav mb-2 mb-lg-0">
+      <li class = "nav-item">
+        <%= image_tag current_user.icon_url, size: "50x50"%>
+      </li>
+      <li class="nav-item">
+       <div class="dropdown">
+          <button type="button" class="btn btn-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+            メニュー
+          </button>
+          <ul class="dropdown-menu">
+            <li><%= link_to 'マイページ', '#',class: "dropdown-item" %></li>
+            <li><%= link_to '設定' ,'#', class: "dropdown-item" %></li>
+            <li><hr class="dropdown-divider"></li>
+            <li><%= link_to 'ログアウト' ,logout_path, data: { turbo_method: :delete },class:"dropdown-item" %></li>
+        </ul>
+      </div>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
   <div class="row">
     <%= form_with model: @user, local: true do |f| %>
+      <%#= render 'shared/error_messages' , object: f.object%>
       <div class="form-group">
         <%= f.label :email %></br>
         <%= f.email_field :email %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,4 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "bootstrap.min.js", preload: true
-pin "@popperjs/core", to: "popper.js", preload: true
+pin "jquery", to: "https://ga.jspm.io/npm:jquery@3.6.3/dist/jquery.js"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,3 +11,4 @@ Rails.application.config.assets.version = "1.0"
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w(bootstrap.min.js popper.js)
+Rails.application.config.assets.paths << Rails.root.join('node_modules')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   root "tops#index"
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => 'user_sessions#create'
-  post 'logout' => 'user_sessions#destroy', :as => :logout
+  delete 'logout' => 'user_sessions#destroy', :as => :logout
   resources :users, only: %i[create new destroy edit update show]
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "popper.js": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
+      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+    }
+  }
+}


### PR DESCRIPTION
非ログイン時にログイン・新規登録、ログイン時に現在ログイン中のアイコンとメニューを表示するように設定しました。ログイン失敗した時にflash messageが表示するように修正しました。
- 非ログイン時
- [x] ログインボタンと新規登録ボタンを表示する
- ログイン時
- [x] ログイン中のユーザーアイコンを表示する
- [x] メニューを右端に設置
- [x] メニューの中をマイページ(url未設定)、設定(url未設定)、ログアウト(ログアウト実行後ログイン画面に遷移)

- ログイン失敗時のフラッシュメッセージ  
 修正前は何も表示されずidとパスワードを入力したままなので、controllerにstatus: :unprocessable_entityを追加して表示できるように変更した 