### PR TITLE
ActionView::Template::Errorの修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
カレンダーアクセス時、ActionView::Template::Error (The asset "watering_icon" is not present in the asset pipeline.)を解消するため、config.assets.compile = trueを修正しました。