### PR TITLE
Fix:autoprefixerのエラーを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@
 
 /public/assets
 /public/uploads
-
+/node_modules
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /vendor

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "bootsnap", require: false
   gem 'sorcery'
   gem 'carrierwave', '>= 3.0.0.beta', '< 4.0'
   gem "mini_magick"
-  gem 'bootstrap', '~>5.0.2'
+  gem 'bootstrap'
   gem 'jquery-rails'
   gem 'enum_help'
   gem 'jp_prefecture'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,9 +74,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.15.0)
       msgpack (~> 1.2)
-    bootstrap (5.0.2)
+    bootstrap (5.2.3)
       autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 2.9.2, < 3)
+      popper_js (>= 2.11.6, < 3)
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     carrierwave (3.0.0.beta)
@@ -266,7 +266,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  bootstrap (~> 5.0.2)
+  bootstrap
   carrierwave (>= 3.0.0.beta, < 4.0)
   debug
   enum_help

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,12 +1,27 @@
 {
   "systemParams": "darwin-arm64-88",
-  "modulesFolders": [],
-  "flags": [
-    "production"
+  "modulesFolders": [
+    "node_modules"
   ],
+  "flags": [],
   "linkedModules": [],
-  "topLevelPatterns": [],
-  "lockfileEntries": {},
+  "topLevelPatterns": [
+    "autoprefixer@10.4.5"
+  ],
+  "lockfileEntries": {
+    "autoprefixer@10.4.5": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz",
+    "browserslist@^4.20.2": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+    "caniuse-lite@^1.0.30001332": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+    "caniuse-lite@^1.0.30001400": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+    "electron-to-chromium@^1.4.251": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+    "escalade@^3.1.1": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+    "fraction.js@^4.2.0": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
+    "node-releases@^2.0.6": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+    "normalize-range@^0.1.2": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+    "picocolors@^1.0.0": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+    "postcss-value-parser@^4.2.0": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+    "update-browserslist-db@^1.0.9": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz"
+  },
   "files": [],
   "artifacts": {}
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "taniku",
   "version": "1.0.0",
   "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/ Coco568/taniku.git"
-  },
+  "repository": "git+ssh://git@github.com/ Coco568/taniku.git",
   "author": "Coco568 <fmrgse3435@yahoo.co.jp>",
   "license": "MIT",
   "description": "多肉植物の成長を実感したい人のための かわいい姿も元気がない姿も買ったばかりの新入りも全て残す 多肉植物記録サービスです。",
@@ -19,5 +16,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "devDependencies": {}
+  "resolutions": {
+    "autoprefixer": "10.4.5"
+  },
+  "dependencies": {
+    "autoprefixer": "10.4.5"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,3 +2,72 @@
 # yarn lockfile v1
 
 
+autoprefixer@10.4.5:
+  version "10.4.5"
+  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.5.tgz"
+  integrity sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==
+  dependencies:
+    browserslist "^4.20.2"
+    caniuse-lite "^1.0.30001332"
+    fraction.js "^4.2.0"
+    normalize-range "^0.1.2"
+    picocolors "^1.0.0"
+    postcss-value-parser "^4.2.0"
+
+browserslist@^4.20.2:
+  version "4.21.4"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz"
+  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+  dependencies:
+    caniuse-lite "^1.0.30001400"
+    electron-to-chromium "^1.4.251"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.9"
+
+caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001400:
+  version "1.0.30001442"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz"
+  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+
+electron-to-chromium@^1.4.251:
+  version "1.4.284"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz"
+  integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+fraction.js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz"
+  integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
+
+node-releases@^2.0.6:
+  version "2.0.8"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz"
+  integrity sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==
+
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
+postcss-value-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+update-browserslist-db@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz"
+  integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"


### PR DESCRIPTION
autoprefixerによって「Replace color-adjust to print-color-adjust. The color-adjust shorthand is currently deprecated.」というエラーが出てrails assets:precompileが行えないことを修正しました。
